### PR TITLE
Improve bilingual site content

### DIFF
--- a/english.html
+++ b/english.html
@@ -79,11 +79,11 @@
         <div class="row intro-content">
 
             <div class="column large-9 mob-full intro-text">
-                <h3>hello,I'm Joachim Wéry</h3>
+                <h3>Hello, I'm Joachim Wéry</h3>
                 <h1>
-                    Full-stack dev<br>
-                    Webdesigner <br>
-                    Graphist
+                    Full-stack developer<br>
+                    Web designer<br>
+                    Graphic designer
                 </h1>
             </div>
 
@@ -116,27 +116,26 @@
             <div class="row about-me__content" data-aos="fade-up">
                 <div class="column large-full about-me__text">
                     <p class="lead">
-                       I'm Joachim Wery
-                       and I'm a recently trained Full-Stack developer and an experienced Webdesigner for almost 2 years. I'm looking for a job in programming or web design.
+                       My name is Joachim Wéry. I'm a recently trained full-stack developer and an experienced web designer for almost two years. I'm looking for a job in programming or web design.
                     </p>
 
                     <p>
-                        I'm fascinated by media and digital. I completed a 3-year diploma in multimedia writing, followed by a 2-year master's degree in transmedia architecture. To stay on the cutting edge, I took a 6-month course in Web Design. I've now decided to pursue my training as a .NET developer specializing in cybersecurity.
+                        I'm fascinated by media and digital technology. I completed a three-year diploma in multimedia writing, followed by a two-year master's degree in transmedia architecture. To stay on the cutting edge, I took a six-month course in web design. I'm now continuing my training as a .NET developer specializing in cybersecurity.
                     </p>
 
                     <p>
-                        I'm a solution-oriented all-rounder with a wide range of skills. I can work in a wide range of fields, from web development and site integration to security and software development.
+                        I'm a solution-oriented all-rounder with a wide range of skills. I can work in a variety of fields, from web development and site integration to security and software development.
                     </p>
 
                     <p>
-                        I'm passionate about discovering new ideas and technical solutions to creative and technical challenges. If you're looking for a junior with an innovative and creative vision, I'm your man. My skills and experience will enable me to make a significant contribution to your company. I'm currently looking for new professional challenges in these fields. Please contact me if you are interested in working with me. I'm ready to take on new and exciting challenges!
+                        I'm passionate about discovering new ideas and technical solutions to creative and technical challenges. If you're looking for a junior with an innovative and creative vision, I'm your man. My skills and experience will enable me to make a significant contribution to your company. I'm currently looking for new professional challenges in these fields. Please contact me if you're interested in working with me—I'm ready to take on new and exciting challenges!
                     </p>
                 </div>
             </div>
     
             <div class="row about-me__buttons">
                 <div class="column large-half tab-full" data-aos="fade-up">
-                    <a href="mailto:joachimwery@outlook.com" class="btn btn--stroke full-width">let's talk about it</a>
+                    <a href="mailto:joachimwery@outlook.com" class="btn btn--stroke full-width">Let's talk</a>
                 </div>
                 <div class="column large-half tab-full" data-aos="fade-up">
                     <a href="cv/CV .NET EN.pdf" class="btn btn--primary full-width">Download my CV</a>
@@ -167,10 +166,10 @@
                             <div class="timeline__header">
                                 <p class="timeline__timeframe">April 2023 - September 2023</p>
                                 <h3 class="item-title">UPARTNER</h3>
-                                <h5>Developer Fullstack</h5>
+                                <h5>Full-stack developer</h5>
                             </div>
                             <div class="timeline__desc">
-                                <p>Production of websites via WordPress and Elementor CMS.Optimization of blog articles as well as images to make sites faster, optimal and optimized.Prototype site creation when putting online.</p>
+                                <p>Production of websites using the WordPress and Elementor CMS. Optimisation of blog articles as well as images to make the sites faster and more efficient. Creation of websites from prototype to go-live.</p>
                             </div>
                         </div>
 
@@ -179,10 +178,10 @@
                             <div class="timeline__header">
                                 <p class="timeline__timeframe">October 2022 - January 2023</p>
                                 <h3 class="item-title">Arkam Agency</h3>
-                                <h5>Webdesigner (intership)</h5>
+                                <h5>Web designer (internship)</h5>
                             </div>
                             <div class="timeline__desc">
-                                <p> Creation of prototype of animated interfaces and communication with a team of developer back-end and front-end for the integration of the final site.  </p>
+                                <p>Creation of animated interface prototypes and communication with back-end and front-end developers to integrate the final site.</p>
                             </div>
                         </div>
 
@@ -191,10 +190,10 @@
                             <div class="timeline__header">
                                 <p class="timeline__timeframe">November 2021 - March 2022</p>
                                 <h3 class="item-title">RedCup Charleroi</h3>
-                                <h5>Community Manger</h5>
+                                <h5>Community Manager</h5>
                             </div>
                             <div class="timeline__desc">
-                                <p>Creatioon and posts programming for the bar during events and special evenings.</p>
+                                <p>Creation and scheduling of posts for the bar during events and special evenings.</p>
                             </div>
                         </div>
 
@@ -203,10 +202,10 @@
                             <div class="timeline__header">
                                 <p class="timeline__timeframe">2017 - 2021</p>
                                 <h3 class="item-title">Bershka</h3>
-                                <h5>Ready -to -wear seller (student job)</h5>
+                                <h5>Ready-to-wear sales associate (student job)</h5>
                             </div>
                             <div class="timeline__desc">
-                                <p>Man manager, customer advice, stock manager and store's reassort.</p>
+                                <p>Responsible for the menswear department, customer advice, stock management and in-store replenishment.</p>
                             </div>
                         </div>
 
@@ -228,7 +227,7 @@
                                 <h5>Training Full-stack .NET development + cybersecurity</h5>
                             </div>
                             <div class="timeline__desc">
-                                <p>Application development in C#, Angular, Javascript and logical interface creation, with a specialization in cybersecurity. </p>
+                                <p>Application development in C#, Angular and JavaScript, and logical interface design with a specialization in cybersecurity.</p>
                              </div>
                             <div class="timeline__header">
                                 <p class="timeline__timeframe"> 2022 - 2023</p>
@@ -236,7 +235,7 @@
                                 <h5>Webdesign UI/UX training</h5>
                             </div>
                             <div class="timeline__desc">
-                                <p>Understanding of the fundamental principles of design, such as composition, color, typography and visual hierarchy.Usable tests and user interface assessments to improve conviviality.Skills development to solve complex design problems and find creative solutions.</p>
+                                <p>Understanding of the fundamental principles of design, such as composition, colour, typography and visual hierarchy. Usability testing and user interface assessments to improve ergonomics. Skills development to solve complex design problems and find creative solutions.</p>
                             </div>
                         </div>
 
@@ -248,7 +247,7 @@
                                 <h5>Master in transmedia architecture</h5>
                             </div>
                             <div class="timeline__desc">
-                                <p>Management of multimedia projects.Learning audiovisual skills in the studio and on the ground.</p>
+                                <p>Management of multimedia projects. Learning audiovisual skills in the studio and on location.</p>
                             </div>
                         </div>
 
@@ -296,7 +295,7 @@
                 <h2 class="section-heading section-heading--centerbottom">Skills</h2>
 
                 <p class="section-desc">
-                    I love exploring new ways of designing elegant and efficient interfaces
+                    I love exploring new ways of designing elegant and efficient interfaces.
                 </p>
             </div>
         </div> <!-- end heading-block -->
@@ -305,9 +304,9 @@
 
             <div class="column item-service" data-aos="fade-up">
                 <div class="item-service__content">
-                    <h4 class="item-title">Full-Stack development</h4>
+                    <h4 class="item-title">Full-stack development</h4>
                     <p>
-                        I'm passionate about development because it's a constantly evolving field, and I'm constantly on the lookout for new frameworks and tools to keep up with the latest trends and technologies.
+                        I'm passionate about development because it's a constantly evolving field. I'm always on the lookout for new frameworks and tools to keep up with the latest trends and technologies.
                     </p>
                 </div>
             </div>
@@ -316,8 +315,8 @@
                 <div class="item-service__content">
                     <h4 class="item-title">Interface design</h4>
                     <p>
-                        I have skills in web design, user experience and user interface. 
-                        This enables me to create websites that are both beautiful and effective, making sure that navigation is simple and intuitive for visitors.
+                        I have skills in web design, user experience and user interface.
+                        This enables me to create websites that are both beautiful and effective, making sure that navigation stays simple and intuitive for visitors.
                     </p>
                 </div>
             </div>
@@ -327,17 +326,17 @@
                     <h4 class="item-title">Graphic designer</h4>
                     <p>
                        I grew up using the Adobe suite from CS4.
-                        I have an excellent understanding of the basic principles of design and a solid experience with the tools of the Adobe suite, such as Photoshop, Illustrator and Indesign.
+                        I have an excellent understanding of the basic principles of design and solid experience with Adobe tools such as Photoshop, Illustrator and InDesign.
                     </p>
                 </div>
             </div>
 
             <div class="column item-service" data-aos="fade-up">
                 <div class="item-service__content">
-                    <h4 class="item-title">communication</h4>
+                    <h4 class="item-title">Communication</h4>
                     <p>
-                       Having done 3 years in multimedia writing, I was able to acquire skills in digital communication.
-                        Whether in community management or in referencing of websites and digital marketing.
+                       After three years studying multimedia writing, I gained strong skills in digital communication.
+                        That covers both community management and search engine optimisation, along with digital marketing.
                     </p>
                 </div>
             </div>
@@ -346,7 +345,7 @@
                 <div class="item-service__content">
                     <h4 class="item-title">Photography</h4>
                     <p>
-                        As a photographer for events and small businesses, I have gained great experience in communication with customers and individuals.I opened a portfolio focused on automotive photography and I also do passion phorography.
+                        As a photographer for events and small businesses, I've gained great experience communicating with customers and clients. I opened a portfolio focused on automotive photography and I also shoot out of passion.
                     </p>
                 </div>
             </div>
@@ -355,7 +354,7 @@
                 <div class="item-service__content">
                     <h4 class="item-title">Video</h4>
                     <p>
-                        I made a few videos in the automotive field, series trailers and I also made clips for The Youtube Cardrage channel. Even today, I film and mount capsules for the Quai10 de Charleroi to promote their films.
+                        I've produced videos in the automotive field, created series trailers and made clips for the Cardrage YouTube channel. I still film and edit short videos for Quai10 in Charleroi to promote their films.
                     </p>
                 </div>
             </div>
@@ -372,7 +371,7 @@
         <div class="row heading-block heading-block--center" data-aos="fade-up">
             <div class="column large-full">
                 <h2 class="section-desc">
-                    Need a website ?
+                    Need a website?
                 </h2>
             </div>
         </div> <!-- end heading-block -->
@@ -380,8 +379,8 @@
         <div class="row cta-content" data-aos="fade-up">
             <div class="column large-full">
                 <p>
-                 Do not hesitate to <a href="mailto:joachimwery.01@gmail.com">contact me</a>
-                For an optimized and design website 
+                    Don't hesitate to <a href="mailto:joachimwery.01@gmail.com">contact me</a>
+                    for a website that's both optimised and beautifully designed.
                 </p>
 
                 <a href="mailto:joachimwery.01@gmail.com" class="btn full-width">CONTACT ME</a>
@@ -424,7 +423,7 @@
                                 Chevalliance
                             </h4>
                             <p class="item-folio__cat">
-                               Site Web
+                                Website
                             </p>
                         </div>
     
@@ -448,11 +447,11 @@
                                 Retros
                             </h4>
                             <p class="item-folio__cat">
-                                Design application
+                                App design
                             </p>
                         </div>
                         <div class="item-folio__caption">
-                            <p>Here is a prototype of an interactive arcade terminal that I created on Figma, designed for the nostalgic for retro games.This terminal was presented at events such as Made in Asia or Japan Expo, offering visitors the possibility of testing a selection of retro games before buying them.But that's not all: it also allows you to order emblematic retro consoles such as Sega, Nintendo, PlayStation, and many more.Thanks to this terminal, you can plunge back into your childhood memories while discovering new exciting games</p>
+                            <p>Here is a prototype of an interactive arcade terminal that I created on Figma for fans of retro games. It was presented at events such as Made in Asia and Japan Expo, giving visitors the opportunity to test a selection of retro games before buying them. It also allows you to order iconic retro consoles such as Sega, Nintendo, PlayStation and many more. Thanks to this terminal, you can dive back into childhood memories while discovering new and exciting games.</p>
                         </div>
                     </div>
                 </div> <!-- end masonry__brick -->
@@ -472,11 +471,11 @@
                                 Namur's stronghold
                             </h4>
                             <p class="item-folio__cat">
-                                Webdesign
+                                Web design
                             </p>
                         </div>
                         <div class="item-folio__caption">
-                            <p>Design of a home page of a restaurant website offering traditional dishes on Namur.</p>
+                            <p>Design of a restaurant homepage offering traditional dishes in Namur.</p>
                         </div>
                     </div>
                 </div> <!-- end masonry__brick -->
@@ -519,11 +518,11 @@
                                 Arkam
                             </h4>
                             <p class="item-folio__cat">
-                                Web Design + Development on WordPress and Elementor
+                                Web design + development on WordPress and Elementor
                             </p>
                         </div>
                         <div class="item-folio__caption">
-                            <p>Arkam is a communication agency based in Mons, specializing in the creation of modern and effective websites.During my internship at Arkam, I had the opportunity to work on several pages of their website using the Elementor tool for WordPress.The websites created by Arkam are tailor -made to meet the needs and objectives of their customers, with particular attention paid to graphic design and user experience.If you are looking to improve your online presence, Arkam is the agency you need.</p>
+                            <p>Arkam is a communication agency based in Mons, specialising in the creation of modern and effective websites. During my internship at Arkam, I had the opportunity to work on several pages of their website using the Elementor tool for WordPress. The websites created by Arkam are tailor-made to meet their customers’ needs and objectives, with particular attention paid to graphic design and user experience. If you’re looking to improve your online presence, Arkam is the agency you need.</p>
                         </div>
                     </div>
                 </div> <!-- end masonry__brick -->
@@ -547,7 +546,7 @@
                             </p>
                         </div>
                         <div class="item-folio__caption">
-                            <p>Layout of automotive items with a retro style.</p>
+                            <p>Layout of automotive articles with a retro style.</p>
                         </div>
                     </div>
                 </div> <!-- end masonry__brick -->
@@ -630,7 +629,7 @@
                 </p>
 
                 <p class="section-desc">
-                Do not hesitate to contact me, I will be delighted to listen to you and help you transform your ideas into reality.  
+                Don't hesitate to contact me. I'll be delighted to listen to you and help turn your ideas into reality.
                 <a href="mailto:joachimwery.01@gmail.com">Contact me</a>.
                 </p>
             </div>
@@ -639,7 +638,7 @@
         <div class="row contact-infos" data-aos="fade-up" data-aos-anchor=".contact-main">
 
             <div class="column large-5 medium-full contact-phone">
-                <h4><Appelez-moi></Appelez-moi></h4>
+                <h4>Call me</h4>
                 <a href="tel:+32497315231">+32 497 31 52 31</a>
             </div>
 

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
         <nav class="header-nav-wrap">
             <ul class="header-main-nav">
                 <li class="current"><a class="smoothscroll" href="#intro" title="intro">Intro</a></li>
-                <li><a class="smoothscroll" href="#about" title="about">A Propos</a></li>
+                <li><a class="smoothscroll" href="#about" title="about">À propos</a></li>
                 <li><a class="smoothscroll" href="#services" title="services">Compétences</a></li>
                 <li><a class="smoothscroll" href="#works" title="works">Travaux</a></li>
                 <li><a class="smoothscroll" href="#contact" title="contact us">Contact</a></li>	
@@ -79,7 +79,7 @@
         <div class="row intro-content">
 
             <div class="column large-9 mob-full intro-text">
-                <h3>Hello, moi c'est Joachim Wéry</h3>
+                <h3>Bonjour, je suis Joachim Wéry</h3>
                 <h1>
                     Full-stack dev<br>
                     Webdesigner <br>
@@ -109,27 +109,26 @@
 
             <div class="row heading-block" data-aos="fade-up">
                 <div class="column large-full">
-                    <h2 class="section-heading">A mon propos</h2>
+                    <h2 class="section-heading">À propos de moi</h2>
                 </div>
             </div>
 
             <div class="row about-me__content" data-aos="fade-up">
                 <div class="column large-full about-me__text">
                     <p class="lead">
-                        Mon nom est JOACHIM WERY et je suis un développeur Full-Stack récemment formé et un Webdesigner expérimenté depuis près de 2 ans. Je cherche un emploi dans le secteur de la programmation ou du Webdesign.
+                        Je m'appelle Joachim Wéry. Je suis un développeur full-stack récemment formé et un webdesigner expérimenté depuis près de deux ans. Je cherche un emploi dans le secteur de la programmation ou du webdesign.
                     </p>
 
                     <p>
-                        Je suis fasciné par les médias et le numérique. J’ai décroché un diplôme de 3 ans en écriture multimédia, puis un master de 2 ans en architecture transmédia. Pour rester à la pointe, j’ai suivi une formation de 6 mois en Web Design. A présent, j’ai choisi de poursuivre avec une formation de développeur .NET spécialisé en cybersécurité.
+                        Je suis fasciné par les médias et le numérique. J’ai décroché un diplôme de trois ans en écriture multimédia, puis un master de deux ans en architecture transmédia. Pour rester à la pointe, j’ai suivi une formation de six mois en webdesign. À présent, je poursuis une formation de développeur .NET spécialisé en cybersécurité.
                     </p>
 
                     <p>
-                        Je suis un polyvalent orienté solution qui dispose de compétences variées. Je peux travailler dans de multiples domaines, du développement web à l’intégration de sites, en passant par la sécurité et le développement logiciel. 
+                        Je suis un profil polyvalent, orienté solution, qui dispose de compétences variées. Je peux travailler dans de multiples domaines, du développement web à l’intégration de sites, en passant par la sécurité et le développement logiciel.
                     </p>
 
                     <p>
-                    
-                        Je suis passionné par la découverte de nouvelles idées et de solutions techniques pour relever des défis créatifs et techniques. Si vous cherchez un junior avec une vision innovante et créative, je suis votre homme. Mes compétences et mon expérience me permettront de contribuer de manière significative à votre entreprise. Je suis actuellement à la recherche de nouveaux défis professionnels dans ces domaines. Contactez-moi pour toute opportunité de travail. Je suis prêt à affronter des défis nouveaux et passionnants !
+                        Je suis passionné par la découverte de nouvelles idées et de solutions techniques pour relever des défis créatifs et techniques. Si vous cherchez un junior avec une vision innovante et créative, je suis votre homme. Mes compétences et mon expérience me permettront de contribuer de manière significative à votre entreprise. Je suis actuellement à la recherche de nouveaux défis professionnels dans ces domaines. Contactez-moi pour toute opportunité de travail : je suis prêt à affronter des défis nouveaux et passionnants !
                     </p>
                 </div>
             </div>
@@ -170,7 +169,7 @@
                                 <h5>Développeur Fullstack</h5>
                             </div>
                             <div class="timeline__desc">
-                                <p>Production de sites internet via CMS Wordpress et Elementor. Optimisation d’articles de blog ainsi que d’images pour rendre les sites plus rapide, optimaux et optimisés. Création de site du prototype à la mise en ligne.</p>
+                                <p>Production de sites internet via les CMS WordPress et Elementor. Optimisation d’articles de blog ainsi que d’images pour rendre les sites plus rapides et performants. Création de sites, du prototype à la mise en ligne.</p>
                             </div>
                         </div>
 
@@ -182,7 +181,7 @@
                                 <h5>Webdesigner (stage)</h5>
                             </div>
                             <div class="timeline__desc">
-                                <p> Création de prototype d’interfaces animeés et communication avec une équipe de développeur Back-end et Front-end pour l’intégration du site final.  </p>
+                                <p>Création de prototypes d’interfaces animées et communication avec une équipe de développeurs back-end et front-end pour l’intégration du site final.</p>
                             </div>
                         </div>
 
@@ -191,10 +190,10 @@
                             <div class="timeline__header">
                                 <p class="timeline__timeframe">Novembre 2021 - Mars 2022</p>
                                 <h3 class="item-title">RedCup Charleroi</h3>
-                                <h5>Community Manger</h5>
+                                <h5>Community Manager</h5>
                             </div>
                             <div class="timeline__desc">
-                                <p>Créatioon et programmation de posts pour le bar lors d'événements et de soirées spéciales.</p>
+                                <p>Création et programmation de publications pour le bar lors d'événements et de soirées spéciales.</p>
                             </div>
                         </div>
 
@@ -228,7 +227,7 @@
                                 <h5>Formation Développement Full-stack .NET + cybersécurité</h5>
                             </div>
                             <div class="timeline__desc">
-                                <p>Développement d'application en C#, Angular, Javascript et création d'interface logique avec une spécialisation en cybersécurité. </p>
+                                <p>Développement d’applications en C#, Angular et JavaScript, et création d’interfaces logiques avec une spécialisation en cybersécurité.</p>
                              </div>
 
                             <div class="timeline__header">
@@ -237,7 +236,7 @@
                                 <h5>Formation Webdesign UI/UX</h5>
                             </div>
                             <div class="timeline__desc">
-                                <p>Compréhension des principes fondamentaux du design, tels que la composition, la couleur, la typographie et la hiérarchie visuelle. Tests d'utilisabilité et des évaluations de l'interface utilisateur pour améliorer la convivialité. Développement de compétences pour résoudre des problèmes de conception complexes et trouver des solutions créatives.</p>
+                                <p>Compréhension des principes fondamentaux du design, tels que la composition, la couleur, la typographie et la hiérarchie visuelle. Tests d’utilisabilité et évaluations de l’interface utilisateur pour améliorer l’ergonomie. Développement de compétences pour résoudre des problèmes de conception complexes et trouver des solutions créatives.</p>
                             </div>
                         </div>
 
@@ -297,7 +296,7 @@
                 <h2 class="section-heading section-heading--centerbottom">Compétences</h2>
 
                 <p class="section-desc">
-                    J’adore explorer de nouvelles façons de concevoir des interfaces élégantes et efficaces
+                    J’adore explorer de nouvelles façons de concevoir des interfaces élégantes et efficaces.
                 </p>
             </div>
         </div> <!-- end heading-block -->
@@ -306,9 +305,9 @@
 
             <div class="column item-service" data-aos="fade-up">
                 <div class="item-service__content">
-                    <h4 class="item-title">Développement Full-Stack</h4>
+                    <h4 class="item-title">Développement full-stack</h4>
                     <p>
-                        Je suis passionné par le développement car c'est un domaine en constante évolution, et je suis constamment à la recherche de nouveaux frameworks et outils pour rester à jour avec les dernières tendances et technologies.
+                        Je suis passionné par le développement car c’est un domaine en constante évolution. Je suis constamment à la recherche de nouveaux frameworks et outils pour rester à jour avec les dernières tendances et technologies.
                     </p>
                 </div>
             </div>
@@ -317,8 +316,8 @@
                 <div class="item-service__content">
                     <h4 class="item-title">Design d'interface</h4>
                     <p>
-                        J'ai des compétences en web design, expérience utilisateur et interface utilisateur. 
-                        Cela me permet de créer des sites web à la fois beaux et efficaces, en m'assurant que la navigation est simple et intuitive pour les visiteurs.
+                        J’ai des compétences en webdesign, en expérience utilisateur et en interface utilisateur.
+                        Cela me permet de créer des sites web à la fois esthétiques et efficaces, en m’assurant que la navigation reste simple et intuitive pour les visiteurs.
                     </p>
                 </div>
             </div>
@@ -327,8 +326,8 @@
                 <div class="item-service__content">
                     <h4 class="item-title">Graphiste</h4>
                     <p>
-                        J'ai grandi en utilisant la suite Adobe depuis CS4.
-                        J'ai une excellente compréhension des principes de base du design et une solide expérience avec les outils de la suite Adobe, tels que Photoshop, Illustrator et InDesign.
+                        J’ai grandi en utilisant la suite Adobe depuis CS4.
+                        J’ai une excellente compréhension des principes de base du design et une solide expérience avec les outils de la suite Adobe, tels que Photoshop, Illustrator et InDesign.
                     </p>
                 </div>
             </div>
@@ -337,8 +336,8 @@
                 <div class="item-service__content">
                     <h4 class="item-title">Communication</h4>
                     <p>
-                        Ayant fait 3 ans en Ecriture Multimédia, j'ai pu acquérir des compétences en Communication Digitale. 
-                        Que ça soit en Community Management ou en référencement de sites web et marketing digital.
+                        Ayant étudié trois ans en écriture multimédia, j’ai acquis des compétences en communication digitale,
+                        tant en community management qu’en référencement de sites web et marketing digital.
                     </p>
                 </div>
             </div>
@@ -347,7 +346,7 @@
                 <div class="item-service__content">
                     <h4 class="item-title">Photographie</h4>
                     <p>
-                        En tant que photographe pour des événements et des petites entreprises, j'ai acquis une grande expérience dans la communication avec les clients et les particuliers. J'ai ouvert un portfolio axé sur la photographie automobile et je fait également de la phorographie par passion.
+                        En tant que photographe pour des événements et des petites entreprises, j’ai acquis une solide expérience de la communication avec les clients et les particuliers. J’ai ouvert un portfolio axé sur la photographie automobile et je pratique également la photographie par passion.
                     </p>
                 </div>
             </div>
@@ -356,7 +355,7 @@
                 <div class="item-service__content">
                     <h4 class="item-title">Vidéo</h4>
                     <p>
-                        J'ai fait quelques vidéos dans le domaine de l'automobile, des trailers de séries et j'ai également fait des clip pour cardrage.be. Aujourd'hui encore, je filme et monte des capsules pour le Quai10 de Charleroi pour promouvoir leurs films.
+                        J’ai réalisé quelques vidéos dans le domaine de l’automobile, des bandes-annonces de séries et des clips pour Cardrage.be. Aujourd’hui encore, je filme et monte des capsules pour le Quai10 de Charleroi afin de promouvoir leurs films.
                     </p>
                 </div>
             </div>
@@ -381,8 +380,8 @@
         <div class="row cta-content" data-aos="fade-up">
             <div class="column large-full">
                 <p>
-                 N'hésitez pas à me <a href="mailto:joachimwery.01@gmail.com">contacter</a>
-                 pour un site optimisé et design 
+                    N’hésitez pas à me <a href="mailto:joachimwery.01@gmail.com">contacter</a>
+                    pour un site optimisé et élégant.
                 </p>
 
                 <a href="mailto:joachimwery.01@gmail.com" class="btn full-width">ME CONTACTER</a>
@@ -453,7 +452,7 @@
                             </p>
                         </div>
                         <div class="item-folio__caption">
-                            <p>Voici un prototype de borne d'arcade interactive que j'ai créé sur Figma, pensé pour les nostalgiques des jeux rétro. Cette borne a été présentée lors d'événements tels que Made in Asia ou Japan Expo, offrant aux visiteurs la possibilité de tester une sélection de jeux rétro avant de les acheter. Mais ce n'est pas tout : elle permet également de commander des consoles rétro emblématiques telles que Sega, Nintendo, Playstation, et bien d'autres encore. Grâce à cette borne, vous pouvez replonger dans vos souvenirs d'enfance tout en découvrant de nouveaux jeux passionnants</p>
+                            <p>Voici un prototype de borne d’arcade interactive que j’ai créé sur Figma pour les nostalgiques des jeux rétro. Cette borne a été présentée lors d’événements tels que Made in Asia ou Japan Expo, offrant aux visiteurs la possibilité de tester une sélection de jeux rétro avant de les acheter. Elle permet également de commander des consoles emblématiques comme Sega, Nintendo, PlayStation et bien d’autres. Grâce à cette borne, vous pouvez replonger dans vos souvenirs d’enfance tout en découvrant de nouveaux jeux passionnants.</p>
                         </div>
                     </div>
                 </div> <!-- end masonry__brick -->
@@ -477,7 +476,7 @@
                             </p>
                         </div>
                         <div class="item-folio__caption">
-                            <p>Design d'une page d'accueil du site web d'un restaurant proposant des plats traditionnels sur Namur.</p>
+                            <p>Design d’une page d’accueil pour un restaurant proposant des plats traditionnels à Namur.</p>
                         </div>
                     </div>
                 </div> <!-- end masonry__brick -->
@@ -524,7 +523,7 @@
                             </p>
                         </div>
                         <div class="item-folio__caption">
-                            <p>Arkam est une agence de communication basée à Mons, spécialisée dans la création de sites internet modernes et efficaces. Pendant mon stage chez Arkam, j'ai eu l'occasion de travailler sur plusieurs pages de leur site web en utilisant l'outil Elementor pour Wordpress. Les sites web créés par Arkam sont conçus sur mesure pour répondre aux besoins et aux objectifs de leurs clients, avec une attention particulière portée au design graphique et à l'expérience utilisateur. Si vous cherchez à améliorer votre présence en ligne, Arkam est l'agence qu'il vous faut.</p>
+                            <p>Arkam est une agence de communication basée à Mons, spécialisée dans la création de sites internet modernes et efficaces. Pendant mon stage chez Arkam, j’ai eu l’occasion de travailler sur plusieurs pages de leur site web en utilisant l’outil Elementor pour WordPress. Les sites web créés par Arkam sont conçus sur mesure pour répondre aux besoins et aux objectifs de leurs clients, avec une attention particulière portée au design graphique et à l’expérience utilisateur. Si vous cherchez à améliorer votre présence en ligne, Arkam est l’agence qu’il vous faut.</p>
                         </div>
                     </div>
                 </div> <!-- end masonry__brick -->
@@ -548,7 +547,7 @@
                             </p>
                         </div>
                         <div class="item-folio__caption">
-                            <p>Mise en page d'articles automobile avec un style rétro.</p>
+                            <p>Mise en page d’articles automobiles avec un style rétro.</p>
                         </div>
                     </div>
                 </div> <!-- end masonry__brick -->
@@ -631,7 +630,7 @@
                 </p>
 
                 <p class="section-desc">
-                N'hésitez pas à me contacter, je serai ravis de vous écouter et vous aider à transformer vos idées en réalité.  
+                N’hésitez pas à me contacter, je serai ravi de vous écouter et de vous aider à transformer vos idées en réalité.
                 <a href="mailto:joachimwery.01@gmail.com">Contactez-moi</a>.
                 </p>
             </div>
@@ -640,7 +639,7 @@
         <div class="row contact-infos" data-aos="fade-up" data-aos-anchor=".contact-main">
 
             <div class="column large-5 medium-full contact-phone">
-                <h4><Appelez-moi></Appelez-moi></h4>
+                <h4>Appelez-moi</h4>
                 <a href="tel:+32497315231">+32 497 31 52 31</a>
             </div>
 


### PR DESCRIPTION
## Summary
- polish the French content for the about, experience, services and portfolio sections with corrected grammar and clearer wording
- update the English version to mirror the refreshed French copy and fix translation issues across headings, timelines and descriptions
- tidy the CTA and contact blocks in both languages, including the phone heading markup

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dbae392f10832ebf2085a87d979f08